### PR TITLE
fix: fixed parameter compatibility(window.fetch)

### DIFF
--- a/src/client/sdk/domain/network.js
+++ b/src/client/sdk/domain/network.js
@@ -221,7 +221,7 @@ export default class Network extends BaseDomain {
       let method;
       let data = '';
       // When request is a string, it is the requested url
-      if (typeof request === 'string') {
+      if (typeof request === 'string' || request instanceof URL) {
         url = request;
         method = initConfig.method || 'get';
         data = initConfig.body;


### PR DESCRIPTION
When the `URL` instance was passed in fetch, it caused a method parsing error