### PR TITLE
Refine styling for DEVTOOLS_OVERLAY, hook more console methods,add Chrome Command Line API, DomDebugger.getEventListeners and Runtime.callFunctionOn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+package-lock.json

--- a/src/client/sdk/domain/dom-debugger.js
+++ b/src/client/sdk/domain/dom-debugger.js
@@ -1,0 +1,33 @@
+import BaseDomain from './domain';
+import { getObjectById, objectFormat } from '../common/remoteObject';
+import nodes from '../common/nodes';
+
+export default class DomDebugger extends BaseDomain {
+  namespace = 'DOMDebugger';
+
+  /**
+   * @type { WeakMap<EventTarget, { [key: string]: (AddEventListenerOptions & { listener: Function, type: string, scriptId?: string, lineNumber?: number, columnNumber?: number })[] }> }
+   * @static
+   * @public
+   */
+  static eventListenersMap = new WeakMap();
+
+  /**
+   * @public
+   */
+  getEventListeners({ objectId }) {
+    const node = getObjectById(objectId);
+    return {
+      listeners: Object.values(DomDebugger.eventListenersMap.get(node) || {}).flat(1).map(v => {
+        const copy = { ...v };
+        // listener -> handler
+        delete copy.listener;
+        copy.handler = copy.originalHandler = objectFormat(v.listener);
+        // capture -> useCapture
+        delete copy.capture;
+        copy.backendNodeId = nodes.getIdByNode(node);
+        return copy;
+      })
+    };
+  }
+}

--- a/src/client/sdk/domain/dom.js
+++ b/src/client/sdk/domain/dom.js
@@ -15,7 +15,13 @@ export default class Dom extends BaseDomain {
   currentSearchKey = '';
 
   /**
-   * set $ and $$ methods
+   * @static
+   * @public
+   */
+  static eventListenersMap = new WeakMap();
+
+  /**
+   * set $, $$ and $x methods
    * @static
    */
   static set$Function() {
@@ -28,6 +34,19 @@ export default class Dom extends BaseDomain {
     if (typeof window.$$ !== 'function') {
       window.$$ = function (selector) {
         return document.querySelectorAll(selector);
+      };
+    }
+
+    if (typeof window.$x !== 'function') {
+      window.$x = function (selector) {
+        const xpathResult = document.evaluate(selector, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+        const elements = [];
+
+        for (let i = 0; i < xpathResult.snapshotLength; i++) {
+          elements.push(xpathResult.snapshotItem(i));
+        }
+
+        return elements;
       };
     }
   }

--- a/src/client/sdk/domain/dom.js
+++ b/src/client/sdk/domain/dom.js
@@ -15,13 +15,6 @@ export default class Dom extends BaseDomain {
   currentSearchKey = '';
 
   /**
-   * @type { WeakMap<EventTarget, { [key: string]: EventListenerOptions & { listener: Function, type: string } }> }
-   * @static
-   * @public
-   */
-  static eventListenersMap = new WeakMap();
-
-  /**
    * set $, $$ and $x methods
    * @static
    */

--- a/src/client/sdk/domain/dom.js
+++ b/src/client/sdk/domain/dom.js
@@ -15,6 +15,7 @@ export default class Dom extends BaseDomain {
   currentSearchKey = '';
 
   /**
+   * @type { WeakMap<EventTarget, { [key: string]: EventListenerOptions & { listener: Function, type: string } }> }
    * @static
    * @public
    */

--- a/src/client/sdk/domain/index.js
+++ b/src/client/sdk/domain/index.js
@@ -98,9 +98,11 @@ export default class ChromeDomain {
   proxyEventListener() {
     const originalAddEventListener = EventTarget.prototype.addEventListener;
     const originalRemoveEventListener = EventTarget.prototype.removeEventListener;
-
     const eventListenersMap = Dom.eventListenersMap;
 
+    /**
+     * @type { EventTarget['addEventListener'] }
+     */
     EventTarget.prototype.addEventListener = function(type, listener, optionOrUseCapture) {
       let options;
       if (typeof optionOrUseCapture === 'object' && optionOrUseCapture !== null) {
@@ -113,12 +115,21 @@ export default class ChromeDomain {
       if (!targetListeners[type]) {
         targetListeners[type] = [];
       }
-      targetListeners[type].push({ listener, once: options.once || false, passive: options.passive || false, capture: options.capture || false });
+      targetListeners[type].push({
+        listener,
+        once: options.once || false,
+        passive: options.passive || false,
+        capture: options.capture || false,
+        type,
+      });
       eventListenersMap.set(this, targetListeners);
 
-      return originalAddEventListener.apply(this, [type, listener, options.capture]);
+      return originalAddEventListener.apply(this, [type, listener, options]);
     };
 
+    /**
+     * @type { EventTarget['removeEventListener'] }
+     */
     EventTarget.prototype.removeEventListener = function(type, listener, optionOrUseCapture) {
       let options;
       if (typeof optionOrUseCapture === 'object' && optionOrUseCapture !== null) {
@@ -144,7 +155,7 @@ export default class ChromeDomain {
       }
       eventListenersMap.set(this, targetListeners);
 
-      return originalRemoveEventListener.apply(this, [type, listener, options.capture]);
+      return originalRemoveEventListener.apply(this, [type, listener, options]);
     };
 
     window.getEventListeners = function(target) {

--- a/src/client/sdk/domain/index.js
+++ b/src/client/sdk/domain/index.js
@@ -39,6 +39,7 @@ export default class ChromeDomain {
   registerProtocol(options) {
     const domains = [
       new Dom(options),
+      new DomDebugger(options),
       new DomStorage(options),
       new Storage(options),
       new Overlay(options),

--- a/src/client/sdk/domain/overlay.js
+++ b/src/client/sdk/domain/overlay.js
@@ -148,7 +148,7 @@ export default class Overlay extends BaseDomain {
         highlightConfig: this.highlightConfig,
       });
 
-      this.expandNode(e.target.parentNode);
+      this.expandNode(target.parentNode);
 
       this.send({
         method: Event.nodeHighlightRequested,
@@ -187,6 +187,7 @@ export default class Overlay extends BaseDomain {
       position: 'fixed',
       zIndex: 99999,
       pointerEvents: 'none',
+      textShadow: 'none',
     });
 
     containerBox.className = DEVTOOL_OVERLAY;
@@ -232,11 +233,13 @@ export default class Overlay extends BaseDomain {
     const { contentColor, paddingColor, marginColor } = highlightConfig;
     const { containerBox, contentBox, marginBox, tooltipsBox } = this.highlightBox;
 
+    const zoom = this.getDocumentZoom();
+
     containerBox.style.display = 'block';
 
     Object.assign(contentBox.style, {
-      left: `${left}px`,
-      top: `${top}px`,
+      left: `${left / zoom.x}px`,
+      top: `${top / zoom.y}px`,
       width: `${contentWidth}px`,
       height: `${contentHeight}px`,
       background: Overlay.rgba(contentColor),
@@ -246,8 +249,8 @@ export default class Overlay extends BaseDomain {
     });
 
     Object.assign(marginBox.style, {
-      left: `${left - margin[3]}px`,
-      top: `${top - margin[0]}px`,
+      left: `${(left / zoom.x) - margin[3]}px`,
+      top: `${(top / zoom.y) - margin[0]}px`,
       width: `${marginWidth}px`,
       height: `${marginHeight}px`,
       borderColor: Overlay.rgba(marginColor),
@@ -267,13 +270,31 @@ export default class Overlay extends BaseDomain {
 
     Object.assign(tooltipsBox.style, {
       background: '#fff',
-      left: `${left - margin[3]}px`,
-      top: isTopPosition ? `${top - margin[0] - 30}px` : `${top + marginHeight + 10}px`,
+      left: `${(left / zoom.x) - margin[3]}px`,
+      top: isTopPosition ? `${(top / zoom.y) - margin[0] - 30}px` : `${(top / zoom.y) + marginHeight + 10}px`,
       filter: 'drop-shadow(0 0 3px rgba(0,0,0,0.3))',
       'border-radius': '2px',
       'font-size': '12px',
       padding: '2px 4px',
       color: '#8d8d8d',
     });
+  }
+
+  /**
+   * @private
+   */
+  getDocumentZoom() {
+    const transform = getComputedStyle(document.body).transform;
+    if (transform === 'none') {
+      return {
+        x: 1,
+        y: 1
+      };
+    }
+    const transformArray = transform.slice(7, -1).split(',');
+    return {
+      x: +transformArray[0],
+      y: +transformArray[3]
+    };
   }
 };

--- a/src/client/sdk/domain/overlay.js
+++ b/src/client/sdk/domain/overlay.js
@@ -63,7 +63,8 @@ export default class Overlay extends BaseDomain {
       !node ||
       [Node.TEXT_NODE, Node.COMMENT_NODE, Node.DOCUMENT_TYPE_NODE].includes(node.nodeType) ||
       ['LINK', 'SCRIPT', 'HEAD'].includes(node.nodeName) ||
-      !(node instanceof HTMLElement)
+      !(node instanceof HTMLElement) ||
+      window.getComputedStyle(node).display === 'none'
     ) {
       return;
     }

--- a/src/client/sdk/domain/protocol.js
+++ b/src/client/sdk/domain/protocol.js
@@ -10,10 +10,11 @@ export default {
     'performSearch', 'getSearchResults', 'discardSearchResults', 'getNodeForLocation', 'setNodeValue',
     'getBoxModel',
   ],
+  DOMDebugger: ['getEventListeners'],
   Network: ['enable', 'getCookies', 'setCookie', 'deleteCookies', 'getResponseBody'],
   Overlay: ['enable', 'highlightNode', 'hideHighlight', 'setInspectMode'],
   Page: ['enable', 'startScreencast', 'stopScreencast', 'getResourceTree', 'getResourceContent'],
-  Runtime: ['enable', 'evaluate', 'getProperties', 'releaseObject'],
+  Runtime: ['enable', 'evaluate', 'getProperties', 'releaseObject', 'callFunctionOn'],
   ScreenPreview: ['startPreview', 'stopPreview'] // ScreenPreview is a custom protocol
 };
 

--- a/src/client/sdk/domain/runtime.js
+++ b/src/client/sdk/domain/runtime.js
@@ -69,7 +69,7 @@ export default class Runtime extends BaseDomain {
           document.body.removeChild(textArea);
         }
         if ('clipboard' in navigator) {
-          navigator.clipboard.writeText(String(object)).catch(e => {
+          navigator.clipboard.writeText(String(object)).catch(() => {
             fallbackCopyTextToClipboard(String(object));
           });
         } else {

--- a/src/client/sdk/domain/runtime.js
+++ b/src/client/sdk/domain/runtime.js
@@ -45,6 +45,9 @@ export default class Runtime extends BaseDomain {
     if (typeof window.copy !== 'function') {
       window.copy = object => {
         function fallbackCopyTextToClipboard(text) {
+          if (typeof document !== 'object') {
+            console.error('Copy text failed, running environment is not a browser');
+          }
           const textArea = document.createElement('textarea');
           textArea.value = text;
           textArea.style.position = 'fixed';
@@ -68,12 +71,13 @@ export default class Runtime extends BaseDomain {
           }
           document.body.removeChild(textArea);
         }
+        const str = String(object);
         if ('clipboard' in navigator) {
-          navigator.clipboard.writeText(String(object)).catch(() => {
-            fallbackCopyTextToClipboard(String(object));
+          navigator.clipboard.writeText(str).catch(() => {
+            fallbackCopyTextToClipboard(str);
           });
         } else {
-          fallbackCopyTextToClipboard(String(object));
+          fallbackCopyTextToClipboard(str);
         }
       };
     }


### PR DESCRIPTION
修复DEVTOOLS_OVERLAY显示的文字会受其他元素样式的影响的问题

~~修复了选择的元素如果宽度是100%，会显示为NaN的问题~~

修复了选择隐藏元素也会高亮显示元素位置的问题

hook了更多console的方法（assert和count有问题就没加，time没找到协议名称也没加）

添加了部分Chrome Command Line API~~，关于getEventListeners的位置我不确定放在这里对不对，下次有空看看能不能把控制台的event的监听显示出来~~

添加DomDebugger.getEventListeners 和 Runtime.callFunctionOn的实现

`经过多次测试，目前DomDebugger.getEventListeners只接收到window对象的监听器请求`，未找到解决办法，控制台中的移除监听按钮是可以使用的

还有个问题，`Debugger类里的scriptid是不对外暴露的，而DomDebugger需要scriptid`。

![image](https://github.com/user-attachments/assets/be4c0157-b297-4f69-8460-d578599a235d)


另外，`覆盖监听的时间或许要提前`，不清楚这块应该怎么改