### PR TITLE
chore: disable logging for html2canvas

### DIFF
--- a/src/client/cdp/domain/screen-preview.js
+++ b/src/client/cdp/domain/screen-preview.js
@@ -14,6 +14,7 @@ export default class ScreenPreview extends BaseDomain {
       useCORS: true,
       imageTimeout: 10000,
       scale: 1,
+      logging: false,
       ignoreElements: (element) => {
         if (!element?.style) return false;
         const { display, opacity, visibility } = element.style;


### PR DESCRIPTION
html2canvas的日志太多，埋没了真正有用的日志，而且一般来说这些截图的日志我们是不关心的
之前：
![image](https://github.com/user-attachments/assets/5ea0f814-65fa-4173-bac7-35260d025469)
之后：
![image](https://github.com/user-attachments/assets/7019922f-695f-47ea-ab21-9b89c4ad92be)
